### PR TITLE
Placeholder default content (asterisk)

### DIFF
--- a/src/Presenters/Presenter.php
+++ b/src/Presenters/Presenter.php
@@ -250,6 +250,30 @@ abstract class Presenter extends PresenterViewBase implements GeneratesResponse
     }
 
     /**
+     * This method will be called for any validation Placeholders printed for a View.
+     * It should return the content which should be in the placeholder before it
+     * displays any error.
+     *
+     * By default, if the default validator has any validations matching the validation
+     * name, this will return * to indicate that the field is required.
+     *
+     * @param $validationName
+     * @return string
+     */
+    private function getPlaceholderDefaultContentByName($validationName)
+    {
+        $defaultValidator = $this->createDefaultValidator();
+
+        foreach ($defaultValidator->validations as $validation) {
+            if ($validation->name == $validationName) {
+                return "*";
+            }
+        }
+
+        return "";
+    }
+
+    /**
      * Performs the validation supplied and if it errors, stores the resultant error in the $validationErrors array.
      *
      * @param Validator $validator
@@ -475,6 +499,13 @@ abstract class Presenter extends PresenterViewBase implements GeneratesResponse
             "GetValidationErrors",
             function ($validationName) {
                 return $this->getValidationErrorsByName($validationName);
+            }
+        );
+
+        $view->attachEventHandler(
+            "GetPlaceholderDefaultContent",
+            function ($validationName) {
+                return $this->getPlaceholderDefaultContentByName($validationName);
             }
         );
 

--- a/src/Views/Validation/Placeholder.php
+++ b/src/Views/Validation/Placeholder.php
@@ -36,7 +36,7 @@ class Placeholder
         $errors = $this->hostingView->getValidationErrors($this->validationName);
         $errorMessages = [];
 
-        $errorHtml = "";
+        $errorHtml = $this->hostingView->getPlaceholderDefaultContent($this->validationName);
 
         foreach ($errors as $error) {
             $errorMessages[] = $error->message;

--- a/src/Views/View.php
+++ b/src/Views/View.php
@@ -362,6 +362,18 @@ abstract class View extends PresenterViewBase implements Deployable
     }
 
     /**
+     * Returns content to be displayed in the placeholder for the given validation name before there are any
+     * validation errors to display. The intent is for this to indicate required fields.
+     *
+     * @param $validationName
+     * @return mixed|null
+     */
+    public function getPlaceholderDefaultContent($validationName)
+    {
+        return $this->raiseEvent("GetPlaceholderDefaultContent", $validationName);
+    }
+
+    /**
      * Allows the view to return persisted model data back to the presenter.
      *
      * Some views persist state between connections. As it is the view that is responsible for the perisistance, it


### PR DESCRIPTION
Placeholder now calls a View method which raises a Presenter event to get the default content to display in a placeholder before it contains any errors. This is intended to allow e.g. a \* to mark required fields.
