### PR TITLE
Adding a flag to set if objects should be associated arrays

### DIFF
--- a/src/Leaves/Leaf.php
+++ b/src/Leaves/Leaf.php
@@ -46,6 +46,11 @@ abstract class Leaf implements GeneratesResponseInterface
      */
     private $reRender = false;
 
+    /**
+     * @var bool If true, objects in the request will be converted to PHP associative arrays. Otherwise they will be stdClass objects.
+     */
+    public $objectsToAssocArrays = false;
+
     public function __construct($name = "")
     {
         $this->model = $this->createModel();
@@ -238,7 +243,7 @@ abstract class Leaf implements GeneratesResponseInterface
             if ($request->post("_leafEventArguments")) {
                 $args = $request->post("_leafEventArguments");
                 foreach ($args as $argument) {
-                    $eventArguments[] = json_decode($argument);
+                    $eventArguments[] = json_decode($argument, $this->objectsToAssocArrays);
                 }
             }
 


### PR DESCRIPTION
In the Derrys project we are expecting an array of arrays back from a javascript request, but it actually returns an array of stdClasses. This flag will allow us to say when we want to return associated arrays rather than objects on a leaf basis. Setting the default to be false so that nothing will be broken (fingers crossed) by this change.
