### PR TITLE
Splitting CSS classes on space when adding/removing.

### DIFF
--- a/src/Leaves/LeafModel.php
+++ b/src/Leaves/LeafModel.php
@@ -125,14 +125,32 @@ class LeafModel
         }
     }
 
+    /**
+     * Ensures an array of string css class names only contains one class per element, by splitting
+     * all elements on spaces and merging the parts into one big array of all class names.
+     *
+     * @param string[] $classNames
+     * @return string[]
+     */
+    private static function arrayifyCssClassNames(array $classNames)
+    {
+        $newClassNames = [];
+        foreach ($classNames as $className) {
+            $splitClassNames = preg_split('/\s+/', $className);
+            $newClassNames = array_merge($newClassNames, $splitClassNames);
+        }
+
+        return $newClassNames;
+    }
+
     public function addCssClassNames(...$classNames)
     {
-        $this->cssClassNames = array_merge($this->cssClassNames, $classNames);
+        $this->cssClassNames = array_merge($this->cssClassNames, self::arrayifyCssClassNames($classNames));
     }
 
     public function removeCssClassNames(...$classNames)
     {
-        $this->cssClassNames = array_diff($this->cssClassNames, $classNames);
+        $this->cssClassNames = array_diff($this->cssClassNames, self::arrayifyCssClassNames($classNames));
     }
 
     public function addHtmlAttribute($attributeName, $attributeValue)
@@ -221,7 +239,7 @@ class LeafModel
     public function getBoundValue($propertyName, $index = null)
     {
         $source = &$this->getBindingSource();
-        
+
         if ($index !== null ){
             if (is_array($source)){
                 $array = &$source[$propertyName];

--- a/tests/unit/Leaves/LeafTest.php
+++ b/tests/unit/Leaves/LeafTest.php
@@ -52,6 +52,22 @@ class LeafTest extends LeafTestCase
         $this->assertContains("A different message", $response);
     }
 
+    public function testCssClassManipulation()
+    {
+        $model = $this->leaf->getModelForTesting();
+
+        $this->assertEquals($model->cssClassNames, [], "cssClassNames is not an empty array");
+
+        $model->addCssClassNames('a-class b-class c-class');
+
+        $this->assertEquals($model->cssClassNames, ["a-class", "b-class", "c-class"], "cssClassNames does not have the expected elements after adding");
+
+        $model->removeCssClassNames('a-class c-class');
+
+        // Only checking the values here because the indexes will be different - b-class will have index 1 in the existing array, but we don't care about that
+        $this->assertEquals(array_values($model->cssClassNames), ["b-class"], "cssClassNames does not have the expected elements after removing");
+    }
+
     /**
      * @return Leaf
      */

--- a/tests/unit/Leaves/LeafTest.php
+++ b/tests/unit/Leaves/LeafTest.php
@@ -58,14 +58,14 @@ class LeafTest extends LeafTestCase
 
         $this->assertEquals($model->cssClassNames, [], "cssClassNames is not an empty array");
 
-        $model->addCssClassNames('a-class b-class c-class');
+        $model->addCssClassNames('a-class b-class c-class', 'd-class');
 
-        $this->assertEquals($model->cssClassNames, ["a-class", "b-class", "c-class"], "cssClassNames does not have the expected elements after adding");
+        $this->assertEquals($model->cssClassNames, ["a-class", "b-class", "c-class", "d-class"], "cssClassNames does not have the expected elements after adding");
 
         $model->removeCssClassNames('a-class c-class');
 
         // Only checking the values here because the indexes will be different - b-class will have index 1 in the existing array, but we don't care about that
-        $this->assertEquals(array_values($model->cssClassNames), ["b-class"], "cssClassNames does not have the expected elements after removing");
+        $this->assertEquals(array_values($model->cssClassNames), ["b-class", "d-class"], "cssClassNames does not have the expected elements after removing");
     }
 
     /**


### PR DESCRIPTION
This ensures our array has 1 class per element.
Added unit tests for the css class names functionality.
