### PR TITLE
add creator functions (create/extend) to ViewBridge.js

### DIFF
--- a/src/Views/ViewBridge.js
+++ b/src/Views/ViewBridge.js
@@ -1378,24 +1378,29 @@ window.rhubarb.validation.sources.fromViewBridge = function (viewBridge) {
 //// ViewBridge creation methods
 
 ViewBridge.create = function (name, creator, parent) {
-    parent = parent || ViewBridge;
+    parent = parent || ViewBridge;
 
-    var viewBridge = function() {
-        parent.apply(this, arguments);
-    };
+    var viewBridge = function() {
+        parent.apply(this, arguments);
+    };
 
-    viewBridge.prototype = new parent();
-    viewBridge.prototype.constructor = viewBridge;
+    viewBridge.prototype = new parent();
+    viewBridge.prototype.constructor = viewBridge;
 
-    var properties = creator.call(viewBridge, parent.prototype);
+    var properties = creator.call(viewBridge, parent.prototype);
 
-    for (var property in properties) {
-        viewBridge.prototype[property] = properties[property];
-    }
+    for (var property in properties) {
+        viewBridge.prototype[property] = properties[property];
+    }
 
     return window.rhubarb.viewBridgeClasses[name] = viewBridge;
 };
 
 ViewBridge.prototype.extend = function (name, creator) {
-    return ViewBridge.create(name, creator, this);
+    return ViewBridge.create(name, creator, this);
 };
+
+
+//// shorthand
+
+window.rhubarb.vb = ViewBridge;

--- a/src/Views/ViewBridge.js
+++ b/src/Views/ViewBridge.js
@@ -1374,3 +1374,28 @@ window.rhubarb.validation.sources.fromViewBridge = function (viewBridge) {
         return viewBridge.getValue();
     };
 };
+
+//// ViewBridge creation methods
+
+ViewBridge.create = function (creator, parent) {
+    parent = parent || ViewBridge;
+
+    var viewBridge = function(leafPath) {
+        parent.apply(this, arguments);
+    };
+
+    viewBridge.prototype = new parent();
+    viewBridge.prototype.constructor = viewBridge;
+
+    var properties = creator.call(viewBridge);
+
+    for (var property in properties) {
+        viewBridge.prototype[property] = properties[property];
+    }
+
+    return viewBridge;
+};
+
+ViewBridge.prototype.extend = function (creator) {
+    return ViewBridge.create(creator, this);
+};

--- a/src/Views/ViewBridge.js
+++ b/src/Views/ViewBridge.js
@@ -1377,10 +1377,10 @@ window.rhubarb.validation.sources.fromViewBridge = function (viewBridge) {
 
 //// ViewBridge creation methods
 
-ViewBridge.create = function (creator, parent) {
+ViewBridge.create = function (name, creator, parent) {
     parent = parent || ViewBridge;
 
-    var viewBridge = function(leafPath) {
+    var viewBridge = function() {
         parent.apply(this, arguments);
     };
 
@@ -1393,9 +1393,9 @@ ViewBridge.create = function (creator, parent) {
         viewBridge.prototype[property] = properties[property];
     }
 
-    return viewBridge;
+    return window.rhubarb.viewBridgeClasses[name] = viewBridge;
 };
 
-ViewBridge.prototype.extend = function (creator) {
-    return ViewBridge.create(creator, this);
+ViewBridge.prototype.extend = function (name, creator) {
+    return ViewBridge.create(name, creator, this);
 };

--- a/src/Views/ViewBridge.js
+++ b/src/Views/ViewBridge.js
@@ -1387,7 +1387,7 @@ ViewBridge.create = function (name, creator, parent) {
     viewBridge.prototype = new parent();
     viewBridge.prototype.constructor = viewBridge;
 
-    var properties = creator.call(viewBridge);
+    var properties = creator.call(viewBridge, parent.prototype);
 
     for (var property in properties) {
         viewBridge.prototype[property] = properties[property];


### PR DESCRIPTION
these are a pair of little friendly functions to make making ViewBridges arguably a little nicer to create.

a ViewBridge creator looks like this:

``` javascript
rhubarb.vb.create('WowMyViewBridge', function(parent) {
  const Wow = this // reference to static class
  this.staticMethod = function(hamster, dog) {
    // me oh my my my
  }

  return {
    instanceProperty: true,
    instanceMethod() {
      // what what
    },
    get instanceProperty() { /* do something */ },
    set instanceProperty(val) { /* wow another thing */ },
    handleInput() { /* magic lights */ },
    onReady() {
      this.certainElement = this.viewNode.getElementsByClassName('js-element')[0]
      this.certainElement.addEventListener('click', event => event.target.background = '#ff2a50')
      this.viewNode.addEventListener('input', this.handleInput)
    }
  }
})
```
