### PR TITLE
URL state for leaves

### DIFF
--- a/src/Leaves/Leaf.php
+++ b/src/Leaves/Leaf.php
@@ -51,19 +51,30 @@ abstract class Leaf implements GeneratesResponseInterface
      */
     public $objectsToAssocArrays = false;
 
-    public function __construct($name = "")
+    /**
+     * @param string $name A name used to reference the leaf. If not provided it will be automatically set to the class name (without namespace)
+     * @param callable|null $initialiseModelBeforeView A callback which will be called before onModelCreated, allowing Leaf constructors to take
+     *                                                 arguments which can be added to the model's data before the View is initialised.
+     * @throws InvalidLeafModelException
+     */
+    public function __construct($name = null, callable $initialiseModelBeforeView = null)
     {
         $this->model = $this->createModel();
-        $this->onModelCreated();
-
-        $this->initialiseView();
 
         if ($this->model === null || !($this->model instanceof LeafModel)) {
             throw new InvalidLeafModelException("The call to createModel on " . get_class($this) .
                 " didn't return a LeafModel class");
         }
 
-        if ($name == "") {
+        if ($initialiseModelBeforeView) {
+            $initialiseModelBeforeView($this->model);
+        }
+
+        $this->onModelCreated();
+
+        $this->initialiseView();
+
+        if ($name == null) {
             $name = StringTools::getShortClassNameFromNamespace(static::class);
         }
 
@@ -76,7 +87,6 @@ abstract class Leaf implements GeneratesResponseInterface
      */
     protected function onModelCreated()
     {
-
     }
 
     /**
@@ -117,7 +127,6 @@ abstract class Leaf implements GeneratesResponseInterface
      *
      * @param $name string The new name for the leaf
      * @param $parentPath string The leaf path for the containing leaf
-     * @return string
      */
     public final function setName($name, $parentPath = "")
     {

--- a/src/Leaves/LeafModel.php
+++ b/src/Leaves/LeafModel.php
@@ -111,7 +111,7 @@ class LeafModel
     }
 
     /**
-     * Return the list of properties that can be exposed publically
+     * Return the list of properties that can be exposed publicly
      *
      * @return array
      */
@@ -231,7 +231,7 @@ class LeafModel
     public function getBoundValue($propertyName, $index = null)
     {
         $source = &$this->getBindingSource();
-        
+
         if ($index !== null ){
             if (is_array($source)){
                 $array = &$source[$propertyName];

--- a/src/Leaves/UrlStateLeaf.php
+++ b/src/Leaves/UrlStateLeaf.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rhubarb\Leaf\Leaves;
+
+use Rhubarb\Crown\Request\WebRequest;
+
+abstract class UrlStateLeaf extends Leaf
+{
+    /** @var UrlStateLeafModel */
+    protected $model;
+
+    protected function createModel()
+    {
+        return new UrlStateLeafModel();
+    }
+
+    public function getUrlStateName()
+    {
+        return $this->model->urlStateName;
+    }
+
+    public function setUrlStateName($name)
+    {
+        $this->model->urlStateName = $name;
+    }
+
+    protected function parseRequest(WebRequest $request)
+    {
+        parent::parseRequest($request);
+
+        $this->parseUrlState($request);
+    }
+
+    protected function parseUrlState(WebRequest $request)
+    {
+        // Override this method to parse the state from the URL for this leaf.
+    }
+}

--- a/src/Leaves/UrlStateLeafModel.php
+++ b/src/Leaves/UrlStateLeafModel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rhubarb\Leaf\Leaves;
+
+class UrlStateLeafModel extends LeafModel
+{
+    /**
+     * @var string The name of the GET param which will provide state for this leaf in the URL
+     */
+    public $urlStateName;
+
+    protected function getExposableModelProperties()
+    {
+        $properties = parent::getExposableModelProperties();
+        $properties[] = 'urlStateName';
+        return $properties;
+    }
+}

--- a/src/Leaves/UrlStateView.php
+++ b/src/Leaves/UrlStateView.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rhubarb\Leaf\Leaves;
+
+use Rhubarb\Crown\Request\WebRequest;
+use Rhubarb\Leaf\Views\View;
+
+class UrlStateView extends View
+{
+    public function getDeploymentPackage()
+    {
+        return new LeafDeploymentPackage(__DIR__ . '/UrlStateViewBridge.js');
+    }
+
+    protected function parseRequest(WebRequest $request)
+    {
+        parent::parseRequest($request);
+
+        $this->parseUrlState($request);
+    }
+
+    protected function parseUrlState(WebRequest $request)
+    {
+        // Override this method to parse the state from the URL for sub-leaves of this view.
+    }
+}

--- a/src/Leaves/UrlStateViewBridge.js
+++ b/src/Leaves/UrlStateViewBridge.js
@@ -1,0 +1,44 @@
+/**
+ * Polyfill for URLSearchParams support courtesy from https://github.com/WebReflection/url-search-params
+ */
+var URLSearchParams=URLSearchParams||function(){"use strict";function e(e){return encodeURIComponent(e).replace(i,u)}function t(e){return decodeURIComponent(e.replace(s," "))}function n(e){this[f]=Object.create(null);if(!e)return;e.charAt(0)==="?"&&(e=e.slice(1));for(var n,r,i=(e||"").split("&"),s=0,o=i.length;s<o;s++)r=i[s],n=r.indexOf("="),-1<n?this.append(t(r.slice(0,n)),t(r.slice(n+1))):r.length&&this.append(t(r),"")}function l(){try{return!!Symbol.iterator}catch(e){return!1}}var r=n.prototype,i=/[!'\(\)~]|%20|%00/g,s=/\+/g,o={"!":"%21","'":"%27","(":"%28",")":"%29","~":"%7E","%20":"+","%00":"\0"},u=function(e){return o[e]},a=l(),f="__URLSearchParams__:"+Math.random();r.append=function(t,n){var r=this[f];t in r?r[t].push(""+n):r[t]=[""+n]},r.delete=function(t){delete this[f][t]},r.get=function(t){var n=this[f];return t in n?n[t][0]:null},r.getAll=function(t){var n=this[f];return t in n?n[t].slice(0):[]},r.has=function(t){return t in this[f]},r.set=function(t,n){this[f][t]=[""+n]},r.forEach=function(t,n){var r=this[f];Object.getOwnPropertyNames(r).forEach(function(e){r[e].forEach(function(r){t.call(n,r,e,this)},this)},this)},r.keys=function(){var t=[];this.forEach(function(e,n){t.push(n)});var n={next:function(){var e=t.shift();return{done:e===undefined,value:e}}};return a&&(n[Symbol.iterator]=function(){return n}),n},r.values=function(){var t=[];this.forEach(function(e){t.push(e)});var n={next:function(){var e=t.shift();return{done:e===undefined,value:e}}};return a&&(n[Symbol.iterator]=function(){return n}),n},r.entries=function(){var t=[];this.forEach(function(e,n){t.push([n,e])});var n={next:function(){var e=t.shift();return{done:e===undefined,value:e}}};return a&&(n[Symbol.iterator]=function(){return n}),n},a&&(r[Symbol.iterator]=r.entries),r.toJSON=function(){return{}},r.toString=function y(){var t=this[f],n=[],r,i,s,o;for(i in t){s=e(i);for(r=0,o=t[i];r<o.length;r++)n.push(s+"="+e(o[r]))}return n.join("&")};var c=Object.defineProperty,h=Object.getOwnPropertyDescriptor,p=function(e){function t(t,n){r.append.call(this,t,n),t=this.toString(),e.set.call(this._usp,t?"?"+t:"")}function n(t){r.delete.call(this,t),t=this.toString(),e.set.call(this._usp,t?"?"+t:"")}function i(t,n){r.set.call(this,t,n),t=this.toString(),e.set.call(this._usp,t?"?"+t:"")}return function(e,r){return e.append=t,e.delete=n,e.set=i,c(e,"_usp",{configurable:!0,writable:!0,value:r})}},d=function(e){return function(t,n){return c(t,"_searchParams",{configurable:!0,writable:!0,value:e(n,t)}),n}},v=function(e){var t=e.append;e.append=r.append,n.call(e,e._usp.search.slice(1)),e.append=t},m=function(e,t){if(!(e instanceof t))throw new TypeError("'searchParams' accessed on an object that does not implement interface "+t.name)},g=function(e){var t=e.prototype,r=h(t,"searchParams"),i=h(t,"href"),s=h(t,"search"),o;!r&&s&&s.set&&(o=d(p(s)),Object.defineProperties(t,{href:{get:function(){return i.get.call(this)},set:function(e){var t=this._searchParams;i.set.call(this,e),t&&v(t)}},search:{get:function(){return s.get.call(this)},set:function(e){var t=this._searchParams;s.set.call(this,e),t&&v(t)}},searchParams:{get:function(){return m(this,e),this._searchParams||o(this,new n(this.search.slice(1)))},set:function(t){m(this,e),o(this,t)}}}))};return g(HTMLAnchorElement),/^function|object$/.test(typeof URL)&&URL.prototype&&g(URL),n}();
+
+var urlStateBridge = function (leafPath) {
+    window.rhubarb.viewBridgeClasses.ViewBridge.apply(this, arguments);
+};
+
+urlStateBridge.prototype = new window.rhubarb.viewBridgeClasses.ViewBridge();
+urlStateBridge.prototype.constructor = urlStateBridge;
+
+urlStateBridge.prototype.getUrlParam = function (paramName) {
+    var existingParams = new URLSearchParams(location.search);
+    return existingParams.get(paramName);
+};
+urlStateBridge.prototype.getUrlStateParam = function () {
+    return this.getUrlParam(this.model.urlStateName);
+};
+
+urlStateBridge.prototype.updateUrlState = function (newParams) {
+    var params = new URLSearchParams(location.search);
+
+    for (var param in newParams) {
+        if (newParams.hasOwnProperty(param)) {
+            if (newParams[param]) {
+                params.set(param, newParams[param]);
+            } else {
+                params.delete(param);
+            }
+        }
+    }
+
+    window.history.replaceState(null, '', '?' + params);
+};
+
+urlStateBridge.prototype.setUrlStateParam = function (value) {
+    var state = {};
+    state[this.model.urlStateName] = value;
+
+    this.updateUrlState(state);
+};
+
+window.rhubarb.viewBridgeClasses.UrlStateViewBridge = urlStateBridge;


### PR DESCRIPTION
This provides helpers on the server and client side for easily persisting the state of leaves on your page in the URL as GET params.

This goes hand-in-hand with implementations of this feature in leaf extension modules:
Table: https://github.com/RhubarbPHP/Module.Leaf.Table/pull/6
Pager: https://github.com/RhubarbPHP/Module.Leaf.Paging/pull/2
Search panel: https://github.com/RhubarbPHP/Module.Leaf.SearchPanel/pull/1

There's also a small new feature in the Leaf contructor, a callable argument allowing leaves to set model data from their own constructor properties before the view is initialised. This is now used by the Table constructor in the linked PR.

Once all the PRs are merged I'll do releases and ensure all the composer requirements match up between the modules.