### PR TITLE
Add ability to suppress the name attribute of the hidden state input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.3.8
+
+* Changed:   Ability to suppress the name attribute of the hidden state input
+
 ### 1.3.7
 
 * Changed:   Ability to suppress the containing form if $suppressContainingForm = true

--- a/src/Leaves/Leaf.php
+++ b/src/Leaves/Leaf.php
@@ -133,6 +133,13 @@ abstract class Leaf implements GeneratesResponseInterface
     }
 
     /**
+     * Suppress containing form if root node
+     */
+    public final function suppressStateInputNameAttribute(){
+        $this->model->suppressStateInputNameAttribute = true;
+    }
+
+    /**
      * Sets the name of the leaf.
      *
      * @param $name string The new name for the leaf

--- a/src/Leaves/LeafModel.php
+++ b/src/Leaves/LeafModel.php
@@ -57,6 +57,11 @@ class LeafModel
     public $suppressContainingForm = false;
 
     /**
+     * @var bool True if the view should suppress the state inputs 'name' attribute. Useful if you do not want the state submitted as part of a form
+     */
+    public $suppressStateInputNameAttribute = false;
+
+    /**
      * Raised when a View needs a sub leaf created for a given name.
      *
      * @var Event

--- a/src/Views/View.php
+++ b/src/Views/View.php
@@ -342,7 +342,7 @@ class View implements Deployable
 
         if ($this->requiresStateInput) {
             $content .= '
-<input type="hidden" name="' . $this->getStateKey() . '" id="' . $this->getStateKey() . '" value="' . htmlentities($state) . '" />';
+<input type="hidden"' . ($this->model->suppressStateInputNameAttribute ? '' : ' name="' . $this->getStateKey() . '"') . ' id="' . $this->getStateKey() . '" value="' . htmlentities($state) . '" />';
         }
 
         if ($this->requiresContainerDiv) {


### PR DESCRIPTION
This has been done as when the name is not included the value does not get submitted as part of a
form