### PR TITLE
Add pagination to Table exportList to handle large data loads on Unislim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.1
+
+* Fixed: Timeouts/Crashes in Table exportList on a large collections
+
 ### 1.0.x
 
 * Added a changelog

--- a/src/Presenters/Application/Table/Table.php
+++ b/src/Presenters/Application/Table/Table.php
@@ -60,6 +60,7 @@ class Table extends HtmlPresenter
      * @var Model
      */
     private $currentRow;
+
     public function __construct(Collection $list = null, $pageSize = 50, $presenterName = "Table")
     {
         parent::__construct($presenterName);

--- a/src/Presenters/Application/Table/Table.php
+++ b/src/Presenters/Application/Table/Table.php
@@ -54,12 +54,12 @@ class Table extends HtmlPresenter
     private $pageSize;
     private $footerProviders = [];
     private $tableCssClassNames = [];
+    public $exportListPageSize = 100;
 
     /**
      * @var Model
      */
     private $currentRow;
-
     public function __construct(Collection $list = null, $pageSize = 50, $presenterName = "Table")
     {
         parent::__construct($presenterName);
@@ -112,9 +112,9 @@ class Table extends HtmlPresenter
         );
 
         $count = $this->collection->count();
-        for($x = 0; $x < $count; $x += 500){
+        for($x = 0; $x < $count; $x += $this->exportListPageSize){
             $tmpCollection = clone $this->collection;
-            $tmpCollection->setRange($x, 500);
+            $tmpCollection->setRange($x, $this->exportListPageSize);
             $tmpCollection->invalidateList();
 
             /** @var Model $item */


### PR DESCRIPTION
exports on large collections were causing time outs on unislim due to lack of pagination 