### PR TITLE
Add includePageData parameter to sendFileAsServerEvent to enable transmission of page data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.4.8
+
+* Changed:  sendFileAsServerEvent now has flag to enable transmission of page data
+
 ### 1.4.7
 
 * Updated:  Fix for booleans in sendFileAsEvent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 1.4.8
 
-* Changed:  sendFileAsServerEvent now has flag to enable transmission of page data
+* Update:  sendFileAsServerEvent no longer submits value of buttons causing button events to fire
 
 ### 1.4.7
 

--- a/src/Views/ViewBridge.js
+++ b/src/Views/ViewBridge.js
@@ -560,10 +560,12 @@ ViewBridge.prototype.getSubLeafValues = function (byPath) {
 
     for (var i in subPresenters) {
         var subPresenter = subPresenters[i];
-        var value = subPresenter.getValue();
 
-        var key = (byPath) ? subPresenter.leafPath : subPresenter.leafName;
-        model[key] = value;
+        if(subPresenter.hasValue()) {
+          var value = subPresenter.getValue();
+          var key = (byPath) ? subPresenter.leafPath : subPresenter.leafName;
+          model[key] = value;
+        }
     }
 
     return model;
@@ -666,13 +668,9 @@ ViewBridge.prototype.raiseClientEvent = function (eventName) {
 };
 
 
-ViewBridge.prototype.sendFileAsServerEvent = function (eventName, file, onProgress, onComplete, onFailure, includePageData) {
+ViewBridge.prototype.sendFileAsServerEvent = function (eventName, file, onProgress, onComplete, onFailure) {
     if (!this.eventHost) {
         this.eventHost = this.findEventHost();
-    }
-
-    if (!includePageData) {
-      includePageData = false;
     }
 
     // If we're not the host we need to find the host and call it's raise event instead.
@@ -714,22 +712,21 @@ ViewBridge.prototype.sendFileAsServerEvent = function (eventName, file, onProgre
 
         formData.append(this.leafPath, file);
 
-        if (includePageData) {
-            var leafValues = hostPresenter.getSubLeafValuesByPath();
-            for (var name in leafValues) {
-                if (leafValues.hasOwnProperty(name)) {
-                    var value = leafValues[name];
+        var leafValues = hostPresenter.getSubLeafValuesByPath();
 
-                    if (value instanceof Date) {
-                        value = value.toISOString();
-                    }
+        for (var name in leafValues) {
+            if (leafValues.hasOwnProperty(name)){
+                var value = leafValues[name];
 
-                    if (typeof value == "boolean") {
-                        value = (value) ? "1" : "0";
-                    }
-
-                    formData.append(name, value);
+                if (value instanceof Date){
+                    value = value.toISOString();
                 }
+
+                if (typeof value == "boolean") {
+                    value = (value) ? "1" : "0";
+                }
+
+                formData.append(name, value);
             }
         }
 

--- a/src/Views/ViewBridge.js
+++ b/src/Views/ViewBridge.js
@@ -666,9 +666,13 @@ ViewBridge.prototype.raiseClientEvent = function (eventName) {
 };
 
 
-ViewBridge.prototype.sendFileAsServerEvent = function (eventName, file, onProgress, onComplete, onFailure) {
+ViewBridge.prototype.sendFileAsServerEvent = function (eventName, file, onProgress, onComplete, onFailure, includePageData) {
     if (!this.eventHost) {
         this.eventHost = this.findEventHost();
+    }
+
+    if (!includePageData) {
+      includePageData = false;
     }
 
     // If we're not the host we need to find the host and call it's raise event instead.
@@ -710,21 +714,22 @@ ViewBridge.prototype.sendFileAsServerEvent = function (eventName, file, onProgre
 
         formData.append(this.leafPath, file);
 
-        var leafValues = hostPresenter.getSubLeafValuesByPath();
+        if (includePageData) {
+            var leafValues = hostPresenter.getSubLeafValuesByPath();
+            for (var name in leafValues) {
+                if (leafValues.hasOwnProperty(name)) {
+                    var value = leafValues[name];
 
-        for (var name in leafValues) {
-            if (leafValues.hasOwnProperty(name)){
-                var value = leafValues[name];
+                    if (value instanceof Date) {
+                        value = value.toISOString();
+                    }
 
-                if (value instanceof Date){
-                    value = value.toISOString();
+                    if (typeof value == "boolean") {
+                        value = (value) ? "1" : "0";
+                    }
+
+                    formData.append(name, value);
                 }
-
-                if (typeof value == "boolean") {
-                    value = (value) ? "1" : "0";
-                }
-
-                formData.append(name, value);
             }
         }
 


### PR DESCRIPTION
This functionality being enabled by default is causing an issue where submitting page data with this
method by default is causing all button actions to fire. So for example, using the HTML5 File
Uploader module is causing all buttons on the page to fire their buttonPressedEvent