### PR TITLE
♻️ Remove final from private functions as they cannot be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.4.16
+
+Fixed:      Issue causing warnings where private methods were also final.
+
 ### 1.4.15
 
 Fixed:      event-processing class was not always removed from the body tag if other code had modified the

--- a/src/Views/View.php
+++ b/src/Views/View.php
@@ -182,7 +182,7 @@ class View implements Deployable
         return $xml;
     }
 
-    final private function getStateString()
+    private function getStateString()
     {
         $stateKey = $this->getStateKey();
 
@@ -194,7 +194,7 @@ class View implements Deployable
         return null;
     }
 
-    final private function getState()
+    private function getState()
     {
         $state = $this->getStateString();
 
@@ -206,7 +206,7 @@ class View implements Deployable
         return null;
     }
 
-    final private function restoreStateIntoModel()
+    private function restoreStateIntoModel()
     {
         $state = $this->getState();
 


### PR DESCRIPTION
Fixed php8 compile time error: Private methods cannot be final as they are never overridden by other classes