### PR TITLE
♻️ Remove final from private functions as they cannot be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.4.17
+
+Fixed:      Issue causing warnings where private methods were also final.
+
 ### 1.4.16
 
 Fixed:      Issue causing warnings where private methods were also final.

--- a/src/Leaves/Leaf.php
+++ b/src/Leaves/Leaf.php
@@ -361,7 +361,7 @@ abstract class Leaf implements GeneratesResponseInterface
         $this->view->deploy($viewIndex);
     }
 
-    final private function render($viewIndex = null)
+    private function render($viewIndex = null)
     {
         $this->model->leafIndex = $viewIndex;
 
@@ -374,7 +374,7 @@ abstract class Leaf implements GeneratesResponseInterface
         return $html;
     }
 
-    final private function renderXhr()
+    private function renderXhr()
     {
         ob_start();
 


### PR DESCRIPTION
Fixed php8 compile time error: Private methods cannot be final as they are never overridden by other classes
Missed some from last time